### PR TITLE
検索paramsの維持とリロードの修正

### DIFF
--- a/app/controllers/cocktails_controller.rb
+++ b/app/controllers/cocktails_controller.rb
@@ -1,10 +1,39 @@
 class CocktailsController < ApplicationController
   def index
+    check_cocktail_params
+    # paramsでURLパラメータを取得 [:q]のパラメータ
     @q = Cocktail.ransack(params[:q])
     @cocktails = @q.result(distinct: true).page(params[:page]).per(5)
   end
-
+  
   def show
+    check_cocktail_params
     @cocktail = Cocktail.find(params[:id])
+  end
+
+  private
+
+  helper_method :cocktail_params
+
+  def cocktail_params
+    {:"q"=>{"name_cont"=>@name,
+            "base_alcohol_cont"=>@base_alcohol,
+            "taste_cont"=>@taste,
+            "glass_type_cont"=>@glass_type,
+            "alcohol_percentage_gteq"=>@alcohol_percentage_gteq,
+            "alcohol_percentage_lteq"=>@alcohol_percentage_lteq,}}
+  end
+
+  def check_cocktail_params
+    @q = params[:q]
+    if @q.nil? == false then
+      @name = params[:q][:name_cont]
+      @base_alcohol= params[:q][:base_alcohol_cont]
+      @taste = params[:q][:taste]
+      @glass_type = params[:q][:glass_type]
+      @alcohol_percentage_gteq = params[:q][:alcohol_percentage_gteq]
+      @alcohol_percentage_lteq = params[:q][:alcohol_percentage_lteq]
+    end
+    
   end
 end

--- a/app/views/cocktails/index.html.slim
+++ b/app/views/cocktails/index.html.slim
@@ -18,7 +18,7 @@ table.table.table-hover
     tbody
         - @cocktails.each do |cocktail|
             tr
-                td = link_to cocktail.name, cocktail
+                td = link_to cocktail.name, cocktail_path(cocktail.id, cocktail_params)
                 td = cocktail.base_alcohol
                 td = cocktail.taste
                 td = cocktail.glass_type

--- a/app/views/cocktails/show.html.slim
+++ b/app/views/cocktails/show.html.slim
@@ -2,8 +2,11 @@ h1 カクテル詳細
 
 .nav.justify-content-end
   = link_to 'ホームへ戻る', home_path, class: 'nav-link'
-.nav.justify-content-end
-  = link_to '検索結果へ戻る', cocktails_path, class: 'nav-link'
+- if @q.nil? == true
+-else
+  .nav.justify-content-end
+    = link_to '検索結果へ戻る', cocktails_path(cocktail_params), class: 'nav-link'
+
 table.table.table-hover
   tbody
     tr
@@ -24,4 +27,3 @@ table.table.table-hover
     tr
       th = Cocktail.human_attribute_name(:cocktail_recipe)
       td = simple_format(h(@cocktail.cocktail_recipe), {}, sanitize: false, wrapper_tag: "div")
-

--- a/spec/system/cocktail_spec.rb
+++ b/spec/system/cocktail_spec.rb
@@ -154,4 +154,42 @@ RSpec.describe "画面のテスト", type: :system do
       end
     end
 
+    describe "ページ移動のパラメータ保持" do
+      before do
+        visit home_path
+      end
+      it "ベースのお酒をウイスキーで検索後ウイスキーの詳細を確認" do
+        select 'ウイスキー', from: 'q[base_alcohol_cont]'
+        click_button '検索'
+        expect(page).to have_selector 'h1', text: 'カクテル検索結果'
+        click_link 'ウイスキー'
+        expect(page).to have_selector 'h1', text: 'カクテル詳細'
+        expect(page).to have_selector 'tbody', text: 'ウイスキー'
+      end
+      it "ホームからウイスキーの詳細を確認" do
+        click_link 'ウイスキー'
+        expect(page).to have_selector 'h1', text: 'カクテル詳細'
+        expect(page).to have_selector 'tbody', text: 'ウイスキー'
+      end
+      it "ベースのお酒を検索後検索結果へ戻る" do
+        select 'ウイスキー', from: 'q[base_alcohol_cont]'
+        click_button '検索'
+        expect(page).to have_selector 'h1', text: 'カクテル検索結果'
+        click_link 'ウイスキー'
+        expect(page).to have_selector 'h1', text: 'カクテル詳細'
+        expect(page).to have_selector 'tbody', text: 'ウイスキー'
+        click_link '検索結果へ戻る'
+        expect(page).to have_selector 'h1', text: 'カクテル検索結果'
+      end
+      it "ベースのお酒を検索後ホームへ戻る" do
+        select 'ウイスキー', from: 'q[base_alcohol_cont]'
+        click_button '検索'
+        expect(page).to have_selector 'h1', text: 'カクテル検索結果'
+        click_link 'ウイスキー'
+        expect(page).to have_selector 'h1', text: 'カクテル詳細'
+        expect(page).to have_selector 'tbody', text: 'ウイスキー'
+        click_link 'ホームへ戻る'
+        expect(page).to have_selector 'h1', text: 'カクテルホーム'
+      end
+    end
 end


### PR DESCRIPTION
1.検索パラメータをカクテル詳細画面に維持する
2.検索結果に戻る際にパラメータを維持する
3.リロードが入ってもパラメータが変化しないようにする